### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     timeout-minutes: 30
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Set up JDK
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version: 8
         distribution: 'temurin'
@@ -30,7 +30,7 @@ jobs:
 
     - name: Upload Test Results
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: Test Results Linux
         path: '**/test-results/**/*.xml'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: 11
           distribution: 'temurin'


### PR DESCRIPTION
## Summary

Pins all GitHub Actions to full commit SHAs instead of floating version tags.

**Why:** A mutable tag (e.g. \`@v4\`) can be force-pushed to point to different — potentially malicious — code. A full SHA is immutable and cannot be redirected.

Each pinned action retains its version tag as a comment for readability:
\`\`\`yaml
uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
\`\`\`

## Test plan
- [x] Verify CI passes with pinned actions
- [x] Confirm pinned SHAs match expected version tags